### PR TITLE
fix: allow lobicornis to merge PR where skipped job are present

### DIFF
--- a/pkg/repository/repository_review.go
+++ b/pkg/repository/repository_review.go
@@ -18,6 +18,8 @@ const (
 	InProgress = "in_progress"
 	// Queued Check state.
 	Queued = "queued"
+	// Skipped Check state.
+	Skipped = "skipped"
 
 	// Approved Review state.
 	Approved = "APPROVED"

--- a/pkg/repository/repository_state.go
+++ b/pkg/repository/repository_state.go
@@ -58,7 +58,7 @@ func (r *Repository) getAggregatedState(ctx context.Context, pr *github.PullRequ
 		return "", err
 	}
 
-	if status == Pending || status == Success {
+	if status == Pending || status == Success || status == Skipped {
 		return status, nil
 	}
 


### PR DESCRIPTION
### Description

This PR allow the bot to merge PR where skipped job are present

ref: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks

> Note: A job that is skipped will report its status as "Success". It will not prevent a pull request from merging, even if it is a required check.